### PR TITLE
Add option to configure rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Create an deployment group for a codedeploy app
  * [`app_name`]: String(required): Name of the coddeploy app
  * [`service_role_arn`]: String(required): IAM role that is used by the deployment group. You can use the [terraform-iam](https://github.com/skyscrapers/terraform-iam/blob/master/README.md#codedeploy_role) module for this.
  * [`autoscaling_groups`]: List(required): Autoscaling groups you want to attach to the deployment group
-
+ * [`rollback_enbled`]: Bool(optional, default: `false`): Whether to enable auto rollback
+ * [`rollback_events`]: List(optional, default: `["DEPLOYMENT_FAILURE"]`): The event types that trigger a rollback
 
 ### Output
 /
@@ -56,6 +57,8 @@ Create an deployment group for a codedeploy app
  * [`app_name`]: String(required): Name of the coddeploy app
  * [`service_role_arn`]: String(required): IAM role that is used by the deployment group. You can use the [terraform-iam](https://github.com/skyscrapers/terraform-iam/blob/master/README.md#codedeploy_role) module for this.
  * [`autoscaling_groups`]: List(required): Autoscaling groups you want to attach to the deployment group
+ * [`rollback_enbled`]: Bool(optional, default: `false`): Whether to enable auto rollback
+ * [`rollback_events`]: List(optional, default: `["DEPLOYMENT_FAILURE"]`): The event types that trigger a rollback
  * [`trigger_target_arn`]: String(required): SNS topic through which notifications are sent.
 
 ### Output
@@ -80,6 +83,8 @@ Create an deployment group for a codedeploy app. This module will filter for tag
  * [`environment`]: String(required): Environment where your codedeploy deployment group is used for
  * [`app_name`]: String(required): Name of the coddeploy app
  * [`service_role_arn`]: String(required): IAM role that is used by the deployment group. You can use the [terraform-iam](https://github.com/skyscrapers/terraform-iam/blob/master/README.md#codedeploy_role) module for this.
+ * [`rollback_enbled`]: Bool(optional, default: `false`): Whether to enable auto rollback
+ * [`rollback_events`]: List(optional, default: `["DEPLOYMENT_FAILURE"]`): The event types that trigger a rollback
  * [`filterkey`]: String(required):  The key of the tag you assigned to the instances belonging to this deployment group
  * [`filtervalue`]: String(required): The value of the tag you assigned to the instances belonging to this deployment group
 
@@ -106,6 +111,8 @@ Create an deployment group for a codedeploy app and will set the notifications. 
  * [`environment`]: String(required): Environment where your codedeploy deployment group is used for
  * [`app_name`]: String(required): Name of the coddeploy app
  * [`service_role_arn`]: String(required): IAM role that is used by the deployment group. You can use the [terraform-iam](https://github.com/skyscrapers/terraform-iam/blob/master/README.md#codedeploy_role) module for this.
+ * [`rollback_enbled`]: Bool(optional, default: `false`): Whether to enable auto rollback
+ * [`rollback_events`]: List(optional, default: `["DEPLOYMENT_FAILURE"]`): The event types that trigger a rollback
  * [`filterkey`]: String(required):  The key of the tag you assigned to the instances belonging to this deployment group
  * [`filtervalue`]: String(required): The value of the tag you assigned to the instances belonging to this deployment group
  * [`trigger_arn`]: String(required): SNS topic through which notifications are sent.

--- a/deployment-group-ec2tag-notify/main.tf
+++ b/deployment-group-ec2tag-notify/main.tf
@@ -3,6 +3,11 @@ resource "aws_codedeploy_deployment_group" "deployment_group" {
   deployment_group_name = "${var.app_name}-${var.environment}"
   service_role_arn      = "${var.service_role_arn}"
 
+  auto_rollback_configuration {
+    enabled = "${var.rollback_enabled}"
+    events  = "${var.rollback_events}"
+  }
+
   trigger_configuration {
       trigger_events = "${var.trigger_events}"
       trigger_name = "${var.trigger_name}"

--- a/deployment-group-ec2tag-notify/variables.tf
+++ b/deployment-group-ec2tag-notify/variables.tf
@@ -10,6 +10,17 @@ variable "service_role_arn" {
   description = "IAM role that is used by the deployment group"
 }
 
+variable "rollback_enabled" {
+  description = "Whether to enable auto rollback"
+  default     = false
+}
+
+variable "rollback_events" {
+  descritpion = "The event types that trigger a rollback"
+  type        = "list"
+  default     = ["DEPLOYMENT_FAILURE"]
+}
+
 variable "filterkey" {
   description = "filter key you want to use for filtering"
 }

--- a/deployment-group-ec2tag-notify/variables.tf
+++ b/deployment-group-ec2tag-notify/variables.tf
@@ -16,7 +16,7 @@ variable "rollback_enabled" {
 }
 
 variable "rollback_events" {
-  descritpion = "The event types that trigger a rollback"
+  description = "The event types that trigger a rollback"
   type        = "list"
   default     = ["DEPLOYMENT_FAILURE"]
 }

--- a/deployment-group-ec2tag/main.tf
+++ b/deployment-group-ec2tag/main.tf
@@ -3,6 +3,11 @@ resource "aws_codedeploy_deployment_group" "deployment_group" {
   deployment_group_name = "${var.app_name}-${var.environment}"
   service_role_arn      = "${var.service_role_arn}"
 
+  auto_rollback_configuration {
+    enabled = "${var.rollback_enabled}"
+    events  = "${var.rollback_events}"
+  }
+
   ec2_tag_filter {
     key   = "${var.filterkey}"
     type  = "KEY_AND_VALUE"

--- a/deployment-group-ec2tag/variables.tf
+++ b/deployment-group-ec2tag/variables.tf
@@ -10,6 +10,17 @@ variable "service_role_arn" {
   description = "IAM role that is used by the deployment group"
 }
 
+variable "rollback_enabled" {
+  description = "Whether to enable auto rollback"
+  default     = false
+}
+
+variable "rollback_events" {
+  descritpion = "The event types that trigger a rollback"
+  type        = "list"
+  default     = ["DEPLOYMENT_FAILURE"]
+}
+
 variable "filterkey" {
   description = "filter key you want to use for filtering"
 }

--- a/deployment-group-ec2tag/variables.tf
+++ b/deployment-group-ec2tag/variables.tf
@@ -16,7 +16,7 @@ variable "rollback_enabled" {
 }
 
 variable "rollback_events" {
-  descritpion = "The event types that trigger a rollback"
+  description = "The event types that trigger a rollback"
   type        = "list"
   default     = ["DEPLOYMENT_FAILURE"]
 }

--- a/deployment-group-notify/main.tf
+++ b/deployment-group-notify/main.tf
@@ -3,6 +3,12 @@ resource "aws_codedeploy_deployment_group" "deployment_group" {
   deployment_group_name = "${var.app_name}-${var.environment}"
   service_role_arn      = "${var.service_role_arn}"
   autoscaling_groups    = ["${var.autoscaling_groups}"]
+
+  auto_rollback_configuration {
+    enabled = "${var.rollback_enabled}"
+    events  = "${var.rollback_events}"
+  }
+
   trigger_configuration {
     trigger_events = "${var.trigger_events}"
     trigger_name = "${var.app_name}-${var.environment}"

--- a/deployment-group-notify/variables.tf
+++ b/deployment-group-notify/variables.tf
@@ -15,6 +15,17 @@ variable "autoscaling_groups" {
   description = "Autoscaling groups you want to attach to the deployment group"
 }
 
+variable "rollback_enabled" {
+  description = "Whether to enable auto rollback"
+  default     = false
+}
+
+variable "rollback_events" {
+  descritpion = "The event types that trigger a rollback"
+  type        = "list"
+  default     = ["DEPLOYMENT_FAILURE"]
+}
+
 variable "trigger_events" {
   description = "events that can trigger the notifications"
   type = "list"

--- a/deployment-group-notify/variables.tf
+++ b/deployment-group-notify/variables.tf
@@ -21,7 +21,7 @@ variable "rollback_enabled" {
 }
 
 variable "rollback_events" {
-  descritpion = "The event types that trigger a rollback"
+  description = "The event types that trigger a rollback"
   type        = "list"
   default     = ["DEPLOYMENT_FAILURE"]
 }

--- a/deployment-group/main.tf
+++ b/deployment-group/main.tf
@@ -3,4 +3,9 @@ resource "aws_codedeploy_deployment_group" "deployment_group" {
   deployment_group_name = "${var.app_name}-${var.environment}"
   service_role_arn      = "${var.service_role_arn}"
   autoscaling_groups    = ["${var.autoscaling_groups}"]
+
+  auto_rollback_configuration {
+    enabled = "${var.rollback_enabled}"
+    events  = "${var.rollback_events}"
+  }
 }

--- a/deployment-group/variables.tf
+++ b/deployment-group/variables.tf
@@ -14,3 +14,14 @@ variable "autoscaling_groups" {
   type        = "list"
   description = "Autoscaling groups you want to attach to the deployment group"
 }
+
+variable "rollback_enabled" {
+  description = "Whether to enable auto rollback"
+  default     = false
+}
+
+variable "rollback_events" {
+  descritpion = "The event types that trigger a rollback"
+  type        = "list"
+  default     = ["DEPLOYMENT_FAILURE"]
+}

--- a/deployment-group/variables.tf
+++ b/deployment-group/variables.tf
@@ -21,7 +21,7 @@ variable "rollback_enabled" {
 }
 
 variable "rollback_events" {
-  descritpion = "The event types that trigger a rollback"
+  description = "The event types that trigger a rollback"
   type        = "list"
   default     = ["DEPLOYMENT_FAILURE"]
 }


### PR DESCRIPTION
Adds the possibility to configure rollbacks for CodeDeploy.

```
~ module.admin_deployment_group.aws_codedeploy_deployment_group.deployment_group
    auto_rollback_configuration.#:                  "0" => "1"
    auto_rollback_configuration.0.enabled:          "" => "true"
    auto_rollback_configuration.0.events.#:         "0" => "1"
    auto_rollback_configuration.0.events.135881253: "" => "DEPLOYMENT_FAILURE"


Plan: 0 to add, 1 to change, 0 to destroy.
```