### PR TITLE
Corrects TF data current and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Compiled files
 *.tfstate
 *.tfstate.backup
+.terraform

--- a/app/codedeploy.tf
+++ b/app/codedeploy.tf
@@ -1,6 +1,4 @@
-data "aws_region" "current" {
-  current = true
-}
+data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
 


### PR DESCRIPTION
I was getting the following warning when doing a terraform plan for: Sweepbright even when pointing to a newer module commit for our CodeDeploy.

`Warning: module.codedeploy_agency.data.aws_region.current: "current": [DEPRECATED] Defaults to current provider region if no other filtering is enabled`

Updated in line with this documentation: https://www.terraform.io/docs/providers/aws/d/region.html

Have pointed my local code version of Sweepbright to the most recent commit : `7c005747a9ed039e6d64cbe5e29a012d659a12d0` and not the old one from Feb 2017.

```
commit cac1925ed3e899cc310425203fb071efdfd4f243
Author: Luca Venturelli <venturel@users.noreply.github.com>
Date:   Thu Feb 2 18:39:32 2017 +0100
    added new module adding notification option (#5)
```