### PR TITLE
Add a prefix to the codedeploy policy for the S3 bucket

### DIFF
--- a/s3bucket/main.tf
+++ b/s3bucket/main.tf
@@ -8,7 +8,7 @@ resource "aws_s3_bucket" "codedeploy_bucket" {
 }
 
 resource "aws_iam_policy" "codedeploy_policy" {
-  name = "codedeploy_s3bucket_access"
+  name = "${var.name_prefix}_codedeploy_s3bucket_access"
 
   policy = <<EOF
 {


### PR DESCRIPTION
This adds the existing `name_prefix` variable to the IAM policy name of the Codedeploy S3 bucket.

Fixes https://github.com/skyscrapers/terraform-codedeploy/issues/11