### PR TITLE
revert path.module workaround

### DIFF
--- a/notify-slack/main.tf
+++ b/notify-slack/main.tf
@@ -51,20 +51,14 @@ data "archive_file" "slack_notification_zip" {
   source_dir = "${path.module}/functions/"
 }
 
-locals {
-  # Solution from this comment to open issue on non-relative paths  # https://github.com/hashicorp/terraform/issues/8204#issuecomment-332239294
-
-  filename = substr(data.archive_file.slack_notification_zip.output_path, length(path.cwd) + 1, -1, )
-  // +1 for removing the "/"
-}
 
 resource "aws_lambda_function" "cd_sns_lambda" {
   function_name = "cd_sns_lambda"
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "lambda-slack.lambda_handler"
 
-  filename         = local.filename
-  source_code_hash = filebase64sha256(local.filename)
+  filename         = "${path.module}/lambda-slack.zip"
+  source_code_hash = filebase64sha256("${path.module}/lambda-slack.zip")
 
   runtime     = "python2.7"
   timeout     = "120"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
the workaround doesn't work anymore after tf 0.12 upgrade and it's no longer needed
## Description
<!--- Describe your changes in detail -->
use `path.module` normally
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/sweepbright/infrastructure/issues/440
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
tf 0.12 upgrade
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested with sweepbright stack

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
